### PR TITLE
[postPage] 메세지 카드와 카드리스트 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import Header from "components/common/Header";
 import NotFoundPage from "pages/NotFoundPage";
+import RollingPaperPage from "pages/RollingPaperPage";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 function App() {
@@ -12,7 +13,7 @@ function App() {
         <Route path="post">
           <Route index element={<>post</>} />
           <Route path=":postId">
-            <Route index element={<>rolling</>} />
+            <Route index element={<RollingPaperPage />} />
             <Route path="message" element={<>message</>} />
           </Route>
         </Route>

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ function App() {
           <Route index element={<>post</>} />
           <Route path=":postId">
             <Route index element={<RollingPaperPage />} />
+            <Route path="edit" element={<RollingPaperPage />} />
             <Route path="message" element={<>message</>} />
           </Route>
         </Route>

--- a/src/apis/rollingPaperPage.js
+++ b/src/apis/rollingPaperPage.js
@@ -1,0 +1,34 @@
+import { TEAM_BASE_URL } from "constants";
+import { POST_INFO_TYPE, MESSAGE, REACTION } from "constants/rollingPaperPage";
+
+const postURL = (postId) => `${TEAM_BASE_URL}recipients/${postId}/`;
+
+export async function getPost(postId) {
+  const response = await fetch(`${postURL(postId)}`);
+  if (!response.ok) {
+    throw new Error("롤링 페이퍼를 불러오는 데 실패했습니다.");
+  }
+  const body = await response.json();
+  console.log(body); //
+  return body;
+}
+
+async function getPostInfo(postId, type, offset = 0, limit = 12) {
+  const query = `?offset=${offset}&limit=${limit}`;
+  const base_url = `${postURL(postId)}${type}/`;
+  const response = await fetch(`${base_url}${query}`);
+  if (!response.ok) {
+    throw new Error(`${POST_INFO_TYPE[type]} 불러오는 데 실패했습니다.`);
+  }
+  const body = await response.json();
+  console.log(body); //
+  return body;
+}
+
+export async function getMessage(postId, offset = 0, limit = 12) {
+  return await getPostInfo(postId, MESSAGE, offset, limit);
+}
+
+export async function getReaction(postId, offset = 0, limit = 3) {
+  return await getPostInfo(postId, REACTION, offset, limit);
+}

--- a/src/assets/icons/plus.svg
+++ b/src/assets/icons/plus.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 1.71436V22.2858" stroke="white" stroke-width="3" stroke-linecap="round"/>
+<path d="M1.71387 12L22.2853 12" stroke="white" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/src/components/RollingPaperPage/Card.js
+++ b/src/components/RollingPaperPage/Card.js
@@ -1,0 +1,5 @@
+function Card() {
+  return <div></div>;
+}
+
+export default Card;

--- a/src/components/RollingPaperPage/Card.js
+++ b/src/components/RollingPaperPage/Card.js
@@ -1,5 +1,21 @@
+import { Link } from "react-router-dom";
+import PlusIcon from "assets/icons/plus.svg";
+import style from "./Card.module.scss";
+
 function Card() {
   return <div></div>;
+}
+
+export function FirstCard() {
+  return (
+    <div className={`${style["rolling-card"]} ${style["rolling-card-first"]}`}>
+      <Link to="message">
+        <div className={style["add-button"]}>
+          <img src={PlusIcon} alt="메세지 추가" />
+        </div>
+      </Link>
+    </div>
+  );
 }
 
 export default Card;

--- a/src/components/RollingPaperPage/Card.js
+++ b/src/components/RollingPaperPage/Card.js
@@ -1,14 +1,38 @@
 import { Link } from "react-router-dom";
 import PlusIcon from "assets/icons/plus.svg";
 import style from "./Card.module.scss";
+import { formatDateWithDot } from "utils/rollingPaperPage";
 
-function Card() {
-  return <div></div>;
+function Card({ message }) {
+  const { content, createdAt, profileImageURL, relationship, sender } = message;
+
+  return (
+    <article className={style.card}>
+      <header>
+        <img
+          className={style.profile}
+          src={profileImageURL}
+          alt="프로필 이미지"
+        />
+        <div>
+          <h2 className="font_20_regular">
+            From. <span className="font_20_bold">{sender}</span>
+          </h2>
+          <p>{relationship}</p>
+        </div>
+      </header>
+      <div className={style.divider}></div>
+      <main className="font_18_regular">{content}</main>
+      <footer className="font_12_regular">
+        {formatDateWithDot(createdAt)}
+      </footer>
+    </article>
+  );
 }
 
 export function FirstCard() {
   return (
-    <div className={`${style["rolling-card"]} ${style["rolling-card-first"]}`}>
+    <div className={`${style.card} ${style["card-first"]}`}>
       <Link to="message">
         <div className={style["add-button"]}>
           <img src={PlusIcon} alt="메세지 추가" />

--- a/src/components/RollingPaperPage/Card.module.scss
+++ b/src/components/RollingPaperPage/Card.module.scss
@@ -1,0 +1,38 @@
+.rolling-card {
+  width: 384px;
+  height: 280px;
+  border-radius: 16px;
+  background-color: var(--white);
+}
+
+.rolling-card-first {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .add-button {
+    width: 56px;
+    height: 56px;
+    padding: 16px;
+    border-radius: 100px;
+    background-color: var(--gray500);
+
+    &:disabled {
+      background-color: var(--gray300);
+    }
+
+    &:hover {
+      background-color: var(--gray600);
+    }
+
+    &:focus,
+    &:active {
+      background-color: var(--gray700);
+    }
+
+    img {
+      width: 24px;
+      height: 24px;
+    }
+  }
+}

--- a/src/components/RollingPaperPage/Card.module.scss
+++ b/src/components/RollingPaperPage/Card.module.scss
@@ -1,11 +1,45 @@
-.rolling-card {
-  width: 384px;
+article.card {
+  padding: 24px;
+}
+
+.card {
+  width: 100%;
   height: 280px;
   border-radius: 16px;
   background-color: var(--white);
+
+  header {
+    height: 76px;
+    display: flex;
+    gap: 14px;
+
+    .profile {
+      width: 56px;
+      height: 56px;
+      border-radius: 100px;
+      border: 1px solid var(--gray200);
+    }
+  }
+
+  .divider {
+    width: 100%;
+    height: 1px;
+    background-color: var(--gray200);
+  }
+
+  main {
+    width: 100%;
+    height: 106px;
+    margin: 16px 0;
+    color: var(--gray600);
+  }
+
+  footer {
+    color: var(--gray400);
+  }
 }
 
-.rolling-card-first {
+.card-first {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/RollingPaperPage/CardList.js
+++ b/src/components/RollingPaperPage/CardList.js
@@ -1,0 +1,5 @@
+function CardList() {
+  return <div></div>;
+}
+
+export default CardList;

--- a/src/components/RollingPaperPage/CardList.js
+++ b/src/components/RollingPaperPage/CardList.js
@@ -1,5 +1,0 @@
-function CardList() {
-  return <div></div>;
-}
-
-export default CardList;

--- a/src/components/RollingPaperPage/Nav.js
+++ b/src/components/RollingPaperPage/Nav.js
@@ -1,0 +1,5 @@
+function Nav() {
+  return <nav></nav>;
+}
+
+export default Nav;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export const TEAM_BASE_URL = "https://rolling-api.vercel.app/6-1/";

--- a/src/constants/rollingPaperPage.js
+++ b/src/constants/rollingPaperPage.js
@@ -1,0 +1,7 @@
+export const MESSAGE = "messages";
+export const REACTION = "reactions";
+
+export const POST_INFO_TYPE = {
+  [MESSAGE]: "메세지를",
+  [REACTION]: "반응을",
+};

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -1,0 +1,15 @@
+import CardList from "components/RollingPaperPage/CardList";
+import Nav from "components/RollingPaperPage/Nav";
+
+function RollingPaperPage() {
+  return (
+    <>
+      <Nav />
+      <section>
+        <CardList />
+      </section>
+    </>
+  );
+}
+
+export default RollingPaperPage;

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -1,14 +1,77 @@
-import CardList from "components/RollingPaperPage/CardList";
+import { useParams, useLocation, Link } from "react-router-dom";
+import { getMessage } from "apis/rollingPaperPage";
 import Nav from "components/RollingPaperPage/Nav";
+import style from "./RollingPaperPage.module.scss";
+import Card, { FirstCard } from "components/RollingPaperPage/Card";
+import { useCallback, useEffect, useState } from "react";
 
 function RollingPaperPage() {
+  const { postId } = useParams();
+
+  const [messages, setMessages] = useState([]);
+  const [loadingError, setLoadingError] = useState(null);
+
+  const location = useLocation();
+  const isEdit = location.pathname.includes("/edit");
+
+  const handleLoad = useCallback(async () => {
+    let result;
+    try {
+      setLoadingError(null);
+      result = await getMessage(postId);
+    } catch (e) {
+      setLoadingError(e);
+      return;
+    }
+
+    const { results: newMessages } = result;
+    setMessages(newMessages);
+  }, [postId, setMessages]);
+
+  useEffect(() => {
+    handleLoad();
+  }, [handleLoad]);
+
   return (
-    <>
+    <main className={style["page-main"]}>
       <Nav />
-      <section>
-        <CardList />
+      <section className={style["card-section"]}>
+        <ButtonList isEdit={isEdit} />
+        <CardList isEdit={isEdit} messages={messages} />
+        {loadingError?.message ? <p>{loadingError.message}</p> : ""}
       </section>
-    </>
+    </main>
+  );
+}
+
+function ButtonList({ isEdit }) {
+  return (
+    <div className={style["button-wrapper"]}>
+      {isEdit ? (
+        <>{/* TODO: 서영님 edit page의 버튼 */}</>
+      ) : (
+        <Link to="edit" className={style.button}>
+          수정하기
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function CardList({ isEdit, messages }) {
+  return (
+    <ol className={style["card-list"]}>
+      {!isEdit && (
+        <li>
+          <FirstCard />
+        </li>
+      )}
+      {messages.map((message) => (
+        <li key={message.id}>
+          <Card message={message} />
+        </li>
+      ))}
+    </ol>
   );
 }
 

--- a/src/pages/RollingPaperPage.module.scss
+++ b/src/pages/RollingPaperPage.module.scss
@@ -1,0 +1,30 @@
+.page-main {
+  background-color: var(--rolling-bg-purple);
+}
+
+.card-section {
+  position: relative;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  @media screen and (max-width: 1248px) {
+    margin: 0 24px;
+  }
+  padding-top: 113px;
+
+  height: 1500px;
+}
+
+.button-wrapper {
+  position: absolute;
+  top: 63px;
+  right: 0px;
+}
+
+.card-list {
+  width: 100%;
+
+  display: grid;
+  gap: 28px 24px;
+  grid-template-columns: repeat(3, 1fr);
+}

--- a/src/utils/rollingPaperPage.js
+++ b/src/utils/rollingPaperPage.js
@@ -1,0 +1,9 @@
+export function formatDateWithDot(dateString) {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = ("0" + (date.getMonth() + 1)).slice(-2);
+  const day = ("0" + date.getDate()).slice(-2);
+  const formattedString = `${year}.${month}.${day}`;
+
+  return formattedString;
+}


### PR DESCRIPTION
## 주요 변경사항

- 개별 롤링페이퍼 페이지의 메세지 카드 구현
- 더하기 버튼 누르면 메세지 생성 페이지(/post/{id}/message) 로 이동
- 수정하기 버튼 누르면 /post/{id}/edit 으로 이동 (수정 버튼 활성화)

## 스크린샷
<img width="911" alt="스크린샷 2024-05-02 오후 3 09 03" src="https://github.com/un0211/ro1ling/assets/24778465/fbee78ae-6c02-4aa4-899e-dbc842bdd424">


## 팀원에게

- 서영님과 작업 공유하기 위해서 폰트나 색상, 기능 구현은 하지 않고 틀 먼저 작업했습니다.
- 다들 확인 후 피드백 또는 이모지 반응 부탁드려요~ 그리고 서영님이 필요하실 때 squash and merge로 합치고 사용하셔도 좋습니다!