### PR TITLE
[postPage] 롤링페이퍼 페이지 반응형 CSS 구현

### DIFF
--- a/src/components/RollingPaperPage/Card.js
+++ b/src/components/RollingPaperPage/Card.js
@@ -66,12 +66,12 @@ function Card({ message, isEdit, onCheck, isChecked }) {
           )}
         </header>
         <div className={styles.divider}></div>
-        <main
-          className={`font-18 ${FONT_CLASS_NAME[font]} ${styles["media-15"]}`}
-        >
+        <main className={`font-18-18-15 ${FONT_CLASS_NAME[font]}`}>
           {content}
         </main>
-        <footer className="font-12">{formatDateWithDot(createdAt)}</footer>
+        <footer className="font-12-12-12">
+          {formatDateWithDot(createdAt)}
+        </footer>
       </article>
       {isOpenModal && (
         <CardModal

--- a/src/components/RollingPaperPage/Card.js
+++ b/src/components/RollingPaperPage/Card.js
@@ -66,7 +66,11 @@ function Card({ message, isEdit, onCheck, isChecked }) {
           )}
         </header>
         <div className={styles.divider}></div>
-        <main className={`font-18 ${FONT_CLASS_NAME[font]}`}>{content}</main>
+        <main
+          className={`font-18 ${FONT_CLASS_NAME[font]} ${styles["media-15"]}`}
+        >
+          {content}
+        </main>
         <footer className="font-12">{formatDateWithDot(createdAt)}</footer>
       </article>
       {isOpenModal && (

--- a/src/components/RollingPaperPage/Card.module.scss
+++ b/src/components/RollingPaperPage/Card.module.scss
@@ -103,9 +103,3 @@ article.card {
 .checked-card {
   opacity: 0.7;
 }
-
-.media-15 {
-  @media screen and (max-width: 768px) {
-    font-size: 15px;
-  }
-}

--- a/src/components/RollingPaperPage/Card.module.scss
+++ b/src/components/RollingPaperPage/Card.module.scss
@@ -11,6 +11,14 @@ article.card {
   // NOTE pointer 추가
   cursor: pointer;
 
+  @media screen and (max-width: 1248px) {
+    height: 284px;
+  }
+
+  @media screen and (max-width: 768px) {
+    height: 230px;
+  }
+
   // NOTE
   .header {
     margin-bottom: 16px;
@@ -35,6 +43,10 @@ article.card {
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+
+    @media screen and (max-width: 768px) {
+      -webkit-line-clamp: 2;
+    }
   }
 
   footer {
@@ -90,4 +102,10 @@ article.card {
 }
 .checked-card {
   opacity: 0.7;
+}
+
+.media-15 {
+  @media screen and (max-width: 768px) {
+    font-size: 15px;
+  }
 }

--- a/src/components/RollingPaperPage/SenderInfo.js
+++ b/src/components/RollingPaperPage/SenderInfo.js
@@ -10,14 +10,13 @@ function SenderInfo({ profileImageURL, relationship, sender }) {
         alt="프로필 이미지"
       />
       <div>
-        <h2 className={`font-20 ${styles["media-18"]}`}>
-          From.{" "}
-          <span className={`font-20-bold ${styles["media-16"]}`}>{sender}</span>
+        <h2 className="font-20-20-18">
+          From. <span className="font-20-20-16-bold">{sender}</span>
         </h2>
         <p
           className={`${styles.badge} ${
             styles[RELATIONSHIPS[relationship]]
-          } font-14`}
+          } font-14-14-14`}
         >
           {relationship}
         </p>

--- a/src/components/RollingPaperPage/SenderInfo.js
+++ b/src/components/RollingPaperPage/SenderInfo.js
@@ -10,8 +10,9 @@ function SenderInfo({ profileImageURL, relationship, sender }) {
         alt="프로필 이미지"
       />
       <div>
-        <h2 className="font-20">
-          From. <span className="font-20-bold">{sender}</span>
+        <h2 className={`font-20 ${styles["media-18"]}`}>
+          From.{" "}
+          <span className={`font-20-bold ${styles["media-16"]}`}>{sender}</span>
         </h2>
         <p
           className={`${styles.badge} ${

--- a/src/components/RollingPaperPage/SenderInfo.module.scss
+++ b/src/components/RollingPaperPage/SenderInfo.module.scss
@@ -38,17 +38,4 @@
       color: var(--green500);
     }
   }
-
-  // NOTE - 폰트 media query 적용
-  .media-18 {
-    @media screen and (max-width: 768px) {
-      font-size: 18px;
-    }
-  }
-  .media-16 {
-    @media screen and (max-width: 768px) {
-      font-size: 16px;
-      line-height: 26px;
-    }
-  }
 }

--- a/src/components/RollingPaperPage/SenderInfo.module.scss
+++ b/src/components/RollingPaperPage/SenderInfo.module.scss
@@ -10,6 +10,7 @@
     border-radius: 100px;
     border: 1px solid var(--gray200);
   }
+
   .badge {
     width: fit-content;
     height: fit-content;
@@ -35,6 +36,19 @@
     &.family {
       background-color: var(--green100);
       color: var(--green500);
+    }
+  }
+
+  // NOTE - 폰트 media query 적용
+  .media-18 {
+    @media screen and (max-width: 768px) {
+      font-size: 18px;
+    }
+  }
+  .media-16 {
+    @media screen and (max-width: 768px) {
+      font-size: 16px;
+      line-height: 26px;
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "styles/global.css";
 import "styles/button.scss";
+import "styles/fonts.scss";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -13,7 +13,7 @@ function RollingPaperPage() {
   const [postInfo, setPostInfo] = useState({
     name: "",
     backgroundColor: "",
-    backgroundImageURL: null,
+    style: null,
   });
   const [messages, setMessages] = useState([]);
   const [loadingError, setLoadingError] = useState(null);
@@ -71,7 +71,9 @@ function RollingPaperPage() {
     setPostInfo({
       name,
       backgroundColor,
-      backgroundImageURL,
+      style: backgroundImageURL
+        ? { backgroundImage: `url(${backgroundImageURL})` }
+        : null,
     });
 
     const { results: newMessages } = messageResult;
@@ -88,9 +90,8 @@ function RollingPaperPage() {
 
   return (
     <main
-      className={`${styles[postInfo.backgroundColor]} ${
-        postInfo.backgroundImageURL ? styles[postInfo.backgroundImageURL] : ""
-      } ${styles["page-main"]}`}
+      className={`${styles[postInfo.backgroundColor]} ${styles["page-main"]}`}
+      style={postInfo.style ?? {}}
     >
       <Nav postInfo={postInfo} />
       <section className={styles["card-section"]}>

--- a/src/pages/RollingPaperPage.module.scss
+++ b/src/pages/RollingPaperPage.module.scss
@@ -1,4 +1,8 @@
 .page-main {
+  @media screen and (max-width: 768px) {
+    min-width: 360px;
+  }
+
   &.beige {
     background-color: var(--rolling-bg-orange);
   }
@@ -18,21 +22,37 @@
 
 .card-section {
   position: relative;
-  width: 100%;
   max-width: 1200px;
   margin: 0 auto;
+  padding: 113px 0;
+
   @media screen and (max-width: 1248px) {
     margin: 0 24px;
+    padding: 93px 0;
   }
-  padding-top: 113px;
 
-  height: 1500px;
+  @media screen and (max-width: 768px) {
+    margin: 0 20px;
+    padding: 80px 0;
+  }
+
+  height: fit-content;
 }
 
 .button-wrapper {
   position: absolute;
   top: 63px;
   right: 0px;
+
+  @media screen and (max-width: 1248px) {
+    // TODO: 버튼을 여러개로 바꾸면서 디자인 어떻게 할지 고민
+    top: 43px;
+  }
+
+  @media screen and (max-width: 768px) {
+    // TODO: 버튼을 여러개로 바꾸면서 디자인 어떻게 할지 고민
+    top: 30px;
+  }
 }
 
 .card-list {
@@ -41,7 +61,17 @@
   display: grid;
   gap: 28px 24px;
   grid-template-columns: repeat(3, 1fr);
+
+  @media screen and (max-width: 1248px) {
+    gap: 16px;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media screen and (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
 }
+
 .select-all-container {
   display: flex;
   gap: 20px;

--- a/src/pages/RollingPaperPage.module.scss
+++ b/src/pages/RollingPaperPage.module.scss
@@ -44,16 +44,6 @@
   position: absolute;
   top: 63px;
   right: 0px;
-
-  @media screen and (max-width: 1248px) {
-    // TODO: 버튼을 여러개로 바꾸면서 디자인 어떻게 할지 고민
-    top: 43px;
-  }
-
-  @media screen and (max-width: 768px) {
-    // TODO: 버튼을 여러개로 바꾸면서 디자인 어떻게 할지 고민
-    top: 30px;
-  }
 }
 
 .card-list {

--- a/src/pages/RollingPaperPage.module.scss
+++ b/src/pages/RollingPaperPage.module.scss
@@ -37,6 +37,7 @@
   }
 
   height: fit-content;
+  min-height: 1000px;
 }
 
 .button-wrapper {

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,0 +1,66 @@
+$bold: 700;
+$regular: 400;
+
+/* NOTE - 처음 생성 시 사용
+ * font-size,
+ * font-weight: 기본값 regular이므로 bold일 때만 명시)
+ */
+@mixin font($size, $weight: $regular) {
+  font-size: $size;
+  font-weight: $weight;
+  line-height: 1.5;
+}
+// NOTE - 반응형에서 font-size 바꾸고 싶을 때 사용
+@mixin size($size) {
+  font-size: $size;
+}
+
+/* NOTE - 반응형 폰트 정의
+ * font-{PC}-{태블릿}-{모바일} 로 명명, 내림차순 정렬
+ */
+.font-20-20-18 {
+  @include font(20px);
+  @media screen and (max-width: 768px) {
+    @include size(18px);
+  }
+}
+
+.font-20-20-16-bold {
+  @include font(20px, $bold);
+  @media screen and (max-width: 768px) {
+    @include size(16px);
+  }
+}
+
+.font-18-18-15 {
+  @include font(18px);
+  @media screen and (max-width: 768px) {
+    @include size(15px);
+  }
+}
+
+.font-14-14-14 {
+  @include font(14px);
+}
+
+.font-12-12-12 {
+  @include font(12px);
+}
+
+/* font family 설정 */
+
+.font-pretendard {
+  font-family: "Pretendard";
+}
+
+.font-noto-sans {
+  font-family: "Noto Sans KR";
+}
+
+.font-nanum-myeongjo {
+  font-family: "Nanum Myeongjo";
+}
+
+.font-nanum-handletter {
+  font-family: "Handletter";
+}


### PR DESCRIPTION
## 주요 변경사항

- 모바일, 태블릿 반응형 구현
- 배경이미지 적용

## 스크린샷
<img width="400" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/8fef940d-fc87-4ba5-aba3-ba1c438dfaf6">
<img width="488" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/ad6df795-c330-4ab3-89cd-9cea2d369b54">
<img width="1098" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/1308acc4-e7ac-4efd-b098-613dcbdf2022">

## 팀원에게

- 자세한 사항 코멘트로 남겨두겠습니다.
