### PR TITLE
[postPage] 내비게이션 반응형 CSS

### DIFF
--- a/src/components/RollingPaperPage/DropDown.module.scss
+++ b/src/components/RollingPaperPage/DropDown.module.scss
@@ -1,6 +1,8 @@
 @import "styles/button";
 
 .drop-down {
+  position: relative;
+
   .menus {
     border-radius: 8px;
     padding: 10px 1px;

--- a/src/components/RollingPaperPage/Nav.js
+++ b/src/components/RollingPaperPage/Nav.js
@@ -11,8 +11,8 @@ function Nav({ postInfo, onURLClick }) {
       <div className={styles.contents}>
         <div className={`${styles.name} font-28-28-18-bold`}>To. {name}</div>
         <div className={styles["post-info"]}>
-          <>{messageCount}명이 작성했어요</>
-          <div className={styles.divider}></div>
+          <div className={styles["PC-only"]}>{messageCount}명이 작성했어요</div>
+          <div className={`${styles.divider} ${styles["PC-only"]}`}></div>
           <div className={styles.tools}>
             <Emojis />
             <Buttons name={name} onURLClick={onURLClick} />

--- a/src/components/RollingPaperPage/Nav.module.scss
+++ b/src/components/RollingPaperPage/Nav.module.scss
@@ -11,25 +11,46 @@
   justify-content: center;
   align-items: center;
 
+  @media screen and (max-width: 1248px) {
+    padding: 0 24px;
+  }
+
+  @media screen and (max-width: 768px) {
+    height: fit-content;
+  }
+
   .contents {
     max-width: 1200px;
     width: 100%;
 
-    position: relative;
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    @media screen and (max-width: 768px) {
+      display: block;
+    }
 
     .name {
       width: 227px;
       height: 42px;
       color: var(--gray800);
+
+      @media screen and (max-width: 768px) {
+        height: 52px;
+        display: flex;
+        align-items: center;
+      }
     }
 
     .post-info {
       display: flex;
       align-items: center;
       gap: 28px;
+
+      @media screen and (max-width: 768px) {
+        height: 52px;
+      }
 
       .tools {
         display: flex;
@@ -56,6 +77,10 @@
   align-items: center;
   gap: 13px;
 
+  @media screen and (max-width: 768px) {
+    gap: 15px;
+  }
+
   * {
     color: var(--gray900);
   }
@@ -78,6 +103,15 @@
   button {
     padding: 6px 16px;
     border: 1px solid var(--gray300);
+
+    @media screen and (max-width: 768px) {
+      padding: 6px 8px;
+
+      img {
+        width: 20px;
+        height: 20px;
+      }
+    }
   }
 }
 
@@ -94,5 +128,11 @@ button {
   img {
     width: 24px;
     height: 24px;
+  }
+}
+
+.PC-only {
+  @media screen and (max-width: 1248px) {
+    display: none;
   }
 }


### PR DESCRIPTION
## 주요 변경사항

- 내비게이션 반응형 CSS 구현했습니다.

## 스크린샷

<img width="874" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/9e30fd05-c839-40ce-961b-eac35aabd871">
<img width="450" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/fa597350-1092-446d-a9da-868ee7b8031c">
<img width="374" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/2ea3f0ad-f353-4052-b096-0fe61ede3014">

## 팀원에게

- 모바일에서 헤더가 빠져야 하는데, 서영님이 반응형 작업 하면서 해주실 것 같아서 제외했습니다.
- 서하님이 만들고계신 컴포넌트 부분 제외하고 완성했습니다.
- 테스트링크 https://ro1ling-test.netlify.app/post/6690 
