### PR TITLE
[Main Page] 메인페이지 반응형 CSS 적용 

### DIFF
--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -10,6 +10,7 @@ function Section({
   rowReverse,
   controlMargin,
   controlFlex,
+  description,
 }) {
   return (
     <section className={`${styles.section}`}>
@@ -24,9 +25,9 @@ function Section({
             styles[controlMargin] ? styles[controlMargin] : ""
           }`}
         >
-          <div className={styles.emphasis}>{point}</div>
-          <h2 className={styles.title}>{title}</h2>
-          <p className={styles.description}>로그인 없이 자유롭게 만들어요.</p>
+          <div className={`${styles.emphasis} font-14-14-14-bold`}>{point}</div>
+          <h2 className={`${styles.title} font-24-24-18-bold`}>{title}</h2>
+          <p className={`${styles.description} font-18-18-15`}>{description}</p>
         </div>
         <img src={imgSrc} alt="롤링페이퍼 예시" className={styles.exampleImg} />
       </div>
@@ -43,6 +44,7 @@ export default function MainPage() {
         title={`누구나 손쉽게, 온라인
            롤링 페이퍼를 만들 수 있어요`}
         controlMargin={"marginLeft"}
+        description={"로그인 없이 자유롭게 만들어요."}
       />
       <Section
         imgSrc={reactionExample}
@@ -51,6 +53,7 @@ export default function MainPage() {
            표현해보세요`}
         rowReverse={"rowReverse"}
         controlFlex={"flexEnd"}
+        description={"롤링 페이퍼에 이모지를 추가할 수 있어요."}
       />
       <Link to="/list" className="button width-280 align-center font-18">
         구경해보기

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -11,6 +11,7 @@ function Section({
   controlMargin,
   controlFlex,
   description,
+  imgMarginTop,
 }) {
   return (
     <section className={`${styles.section}`}>
@@ -29,7 +30,13 @@ function Section({
           <h2 className={`${styles.title} font-24-24-18-bold`}>{title}</h2>
           <p className={`${styles.description} font-18-18-15`}>{description}</p>
         </div>
-        <img src={imgSrc} alt="롤링페이퍼 예시" className={styles.exampleImg} />
+        <img
+          src={imgSrc}
+          alt="롤링페이퍼 예시"
+          className={`${styles.exampleImg} ${
+            imgMarginTop ? styles["img-margin-top"] : ""
+          }`}
+        />
       </div>
     </section>
   );
@@ -54,8 +61,12 @@ export default function MainPage() {
         rowReverse={"rowReverse"}
         controlFlex={"flexEnd"}
         description={"롤링 페이퍼에 이모지를 추가할 수 있어요."}
+        imgMarginTop={"img-margin-top"}
       />
-      <Link to="/list" className="button width-280 align-center font-18">
+      <Link
+        to="/list"
+        className={`button width-280 align-center font-18 ${styles["list-button"]}`}
+      >
         구경해보기
       </Link>
     </main>

--- a/src/pages/MainPage.module.scss
+++ b/src/pages/MainPage.module.scss
@@ -60,9 +60,6 @@
 
         .emphasis {
           border-radius: 50px;
-          font-weight: var(--bold);
-          font-size: 14px;
-          //line-height: 20px;
           background-color: var(--primary-color);
           color: var(--white);
           width: 80px;
@@ -73,9 +70,6 @@
           margin-bottom: 8px;
         }
         .title {
-          font-weight: var(--bold);
-          font-size: 24px;
-          line-height: 36px;
           white-space: pre-line;
 
           @media screen and (max-width: 768px) {
@@ -83,8 +77,6 @@
           }
         }
         .description {
-          font-weight: var(--regular);
-          font-size: 18px;
           color: var(--gray500);
         }
       }

--- a/src/pages/MainPage.module.scss
+++ b/src/pages/MainPage.module.scss
@@ -1,26 +1,31 @@
 .main {
   max-width: 1200px;
   width: 100%;
-  @media screen and (max-width: 1249px) {
+  margin: 60px auto 174px;
+  @media screen and (max-width: 1248px) {
     /*1248보다 작은 화면에 적용*/
     padding: 0 24px;
+    margin: 49px auto 24px;
   }
-  margin: 60px auto;
   display: flex;
   flex-direction: column;
   gap: 30px;
+  @media screen and (max-width: 768px) {
+    gap: 24px;
+    min-width: 360px;
+  }
 
   .section {
     display: flex;
     padding: 60px 0 60px;
-    background-color: var(--surface);
-    border-radius: 16px;
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1248px) {
       padding: 40px 0 40px;
     }
-    @media screen and (max-width: 480px) {
-      padding: 24px 0 50px;
+    @media screen and (max-width: 768px) {
+      padding: 24px 0 40px;
     }
+    background-color: var(--surface);
+    border-radius: 16px;
 
     .rowReverse {
       flex-direction: row-reverse;
@@ -32,18 +37,18 @@
       flex-wrap: wrap;
       justify-content: space-between;
       overflow: hidden;
-      @media screen and (max-width: 768px) {
+      @media screen and (max-width: 1248px) {
         flex-direction: column;
         justify-content: center;
         gap: 36px;
       }
-      @media screen and (max-width: 480px) {
-        gap: 48px;
+      @media screen and (max-width: 768px) {
+        gap: 0px;
       }
 
       .marginLeft {
         margin-left: 60px;
-        @media screen and (max-width: 768px) {
+        @media screen and (max-width: 1248px) {
           margin-left: 0;
         }
       }
@@ -51,11 +56,12 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
-        @media screen and (max-width: 768px) {
-          margin-left: 40px;
+
+        @media screen and (max-width: 1248px) {
+          margin: 0 40px;
         }
-        @media screen and (max-width: 480px) {
-          margin-left: 24px;
+        @media screen and (max-width: 768px) {
+          margin: 0 24px;
         }
 
         .emphasis {
@@ -72,8 +78,11 @@
         .title {
           white-space: pre-line;
 
-          @media screen and (max-width: 768px) {
+          @media screen and (max-width: 1248px) {
             white-space: normal;
+          }
+          @media screen and (max-width: 768px) {
+            white-space: pre-line;
           }
         }
         .description {
@@ -85,9 +94,28 @@
       justify-content: flex-end;
     }
     .exampleImg {
-      @media screen and (max-width: 480px) {
-        object-fit: cover;
+      @media screen and (max-width: 1248px) {
+        width: 100%;
+      }
+      @media screen and (max-width: 768px) {
+        width: 130%;
+        position: relative;
+        left: -45px;
       }
     }
+  }
+}
+.list-button {
+  margin-top: 18px;
+  @media screen and (max-width: 1248px) {
+    margin-top: 42px;
+  }
+  @media screen and (max-width: 768px) {
+    margin-top: 37px;
+  }
+}
+.img-margin-top {
+  @media screen and (max-width: 768px) {
+    margin-top: 48px;
   }
 }

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -67,7 +67,8 @@
   @include btn-basic;
 
   &.align-center {
-    margin: 0 auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   /* size */
@@ -80,7 +81,7 @@
     @include btn-large;
     width: 280px;
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1248px) {
       width: 100%;
     }
   }

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -25,6 +25,13 @@ $regular: 400;
   }
 }
 
+.font-24-24-18-bold {
+  @include font(24px, $bold);
+  @media screen and (max-width: 768px) {
+    @include size(18px);
+  }
+}
+
 .font-20-20-20 {
   @include font(20px);
 }
@@ -56,6 +63,10 @@ $regular: 400;
 
 .font-14-14-14 {
   @include font(14px);
+}
+
+.font-14-14-14-bold {
+  @include font(14px, $bold);
 }
 
 .font-12-12-12 {


### PR DESCRIPTION
## 주요 변경사항

- global.css에 정의된 폰트 클래스에서 font.scss에 정의된 폰트 클래스로 변경
- 모바일에서 이미지 꽉 차면서 잘리도록 변경

## 스크린샷

데스크탑 
![localhost_3000_ (1)](https://github.com/un0211/ro1ling/assets/135966211/ae0d86f3-5a45-4707-b5c1-e1818e92f717)

테블릿 
![image](https://github.com/un0211/ro1ling/assets/135966211/daca62e0-3318-413c-b312-93df7c987ee5)


모바일
![localhost_3000_(iPhone XR)](https://github.com/un0211/ro1ling/assets/135966211/7b7127c7-41ef-487e-8d53-e7ac9d948dde)


## 팀원에게
![localhost_3000_(iPad Air) (4)](https://github.com/un0211/ro1ling/assets/135966211/d0362ed1-01f1-482e-8a86-523dcc772876)

- 개발자 도구 capture full size 하는데 테블릿에서만 이렇게 나오더라구요 max-width:1200px;를 해지해보면 의도한 대로 돼요 그런데 어떻게 수정해야 되는 건지 모르겠어서 여쭤봅니다... 
-
