### PR TITLE
[CountMessage] 디자인 수정 + 롤링페이퍼 페이지에 적용

### DIFF
--- a/src/components/ListPage/CardList.js
+++ b/src/components/ListPage/CardList.js
@@ -3,10 +3,9 @@ import { Link } from "react-router-dom";
 import styles from "./CardList.module.scss";
 import CountMessage from "components/common/CountMessage";
 import TopReaction from "components/common/TopReaction";
-
+import { LIST_PAGE } from "constants";
 
 function CardList({ slideItems }) {
-
   const {
     id,
     name,
@@ -18,22 +17,27 @@ function CardList({ slideItems }) {
     recentMessages,
   } = slideItems;
 
+  const messageProfiles = recentMessages.map(
+    (message) => message.profileImageURL
+  );
+
   const cardStyle = {
     backgroundColor: `var(--${backgroundColor}200)`,
     backgroundImage: `url(${backgroundImageURL})`,
   };
-  console.log(slideItems);
+
   return (
     <div className={styles.CardList} style={cardStyle}>
       <Link to={`/post/${id}`} className={styles.CardList}>
         <h3 className={`font-24-bold`}>To. {name}</h3>
         <CountMessage
-        recentMessages={recentMessages}
-        messageCount={messageCount}
+          messageProfiles={messageProfiles}
+          messageCount={messageCount}
+          page={LIST_PAGE}
         />
         <TopReaction
-        topReactions={topReactions}
-        reactionCount={reactionCount}
+          topReactions={topReactions}
+          reactionCount={reactionCount}
         />
       </Link>
     </div>

--- a/src/components/RollingPaperPage/Nav.js
+++ b/src/components/RollingPaperPage/Nav.js
@@ -1,4 +1,6 @@
+import CountMessage from "components/common/CountMessage";
 import DropDown from "./DropDown";
+import { POST_PAGE } from "constants";
 import arrowDownIcon from "assets/icons/arrow_down.svg";
 import addEmojiIcon from "assets/icons/add_emoji.svg";
 import styles from "./Nav.module.scss";
@@ -11,7 +13,13 @@ function Nav({ postInfo, onURLClick }) {
       <div className={styles.contents}>
         <div className={`${styles.name} font-28-28-18-bold`}>To. {name}</div>
         <div className={styles["post-info"]}>
-          <div className={styles["PC-only"]}>{messageCount}명이 작성했어요</div>
+          <div className={styles["PC-only"]}>
+            <CountMessage
+              messageCount={messageCount}
+              messageProfiles={messageProfiles}
+              page={POST_PAGE}
+            />
+          </div>
           <div className={`${styles.divider} ${styles["PC-only"]}`}></div>
           <div className={styles.tools}>
             <Emojis />

--- a/src/components/common/CountMessage.js
+++ b/src/components/common/CountMessage.js
@@ -1,26 +1,27 @@
 import styles from "./CountMessage.module.scss";
 
-function CountMessage({ recentMessages, messageCount }) {
-
-
+function CountMessage({ messageProfiles, messageCount, page }) {
   return (
-    <div>
+    <div className={styles[page]}>
       <div className={styles.profiles}>
-        {recentMessages && recentMessages.length > 0 ? (
-          recentMessages.map((message) => (
+        {messageProfiles &&
+          messageProfiles.map((profileImageURL) => (
             <img
-              key={message.id}
               className={styles.profile}
-              src={message.profileImageURL}
+              src={profileImageURL}
               alt={`프로필 이미지`}
             />
-          ))
-        ) : (
-          <div>No recent messages</div>
+          ))}
+        {messageCount > 3 && (
+          <div className={`${styles["extra-profile"]} font-12-12-12`}>
+            {" "}
+            +{messageCount - 3}
+          </div>
         )}
-      {messageCount > 3 && <div className={styles["extra-profile"]}> +{messageCount - 3}</div>}
       </div>
-      <div className={styles["message-count"]}>{messageCount}명이 작성했어요!</div>
+      <div className={`${styles["message-count"]} font-16-16-14`}>
+        <span className={styles.bold}>{messageCount}</span>명이 작성했어요!
+      </div>
     </div>
   );
 }

--- a/src/components/common/CountMessage.module.scss
+++ b/src/components/common/CountMessage.module.scss
@@ -1,47 +1,71 @@
-.profiles{
-  width: 90px;
-  height: 28px;
+.profiles {
   position: relative;
   display: flex;
-  margin-top: 12px;
-  margin-bottom: 12px;
+  height: 28px; // NOTE - 프로필 사진이 없는 경우 때문에 추가
 
-  .profile{
-    position: absolute;
+  .profile {
     border: 1px solid var(--white);
-    width: 25px;
-    height: 25px;
+    width: 28px;
+    height: 28px;
     border-radius: 50%;
     margin-right: 10px;
   }
-  .profile:nth-child(1) {
-    top: 0;
-    left: 0;
+
+  .profile:nth-child(n + 2) {
+    position: absolute;
   }
-  
+
   .profile:nth-child(2) {
     top: 0;
-    left: 15px;
+    left: 16px;
   }
 
   .profile:nth-child(3) {
     top: 0;
-    left: 30px;
+    left: 32px;
   }
-  .extra-profile{
+
+  .extra-profile {
     position: absolute;
-    border: 1px solid var(--white);
-    height: 25px;
-    border-radius: 40%;
     top: 0;
-    left: 45px;
-    padding: 5px 7px;
+    left: 48px;
+
+    border-radius: 30px;
+    border: 1px solid var(--white);
     background-color: var(--white);
+    color: var(--gray500);
+    padding: 5px 6px;
     text-align: center;
   }
 
-  .message-count{
-    text-decoration: none;
+  .message-count {
     color: var(--gray700);
+  }
+}
+
+.bold {
+  font-weight: 700;
+}
+
+.list {
+  .profiles {
+    margin: 12px 0;
+  }
+}
+
+.post {
+  display: flex;
+  gap: 16px;
+
+  .profiles {
+    width: 76px;
+
+    .extra-profile {
+      border: 1px solid var(--gray-bolder);
+    }
+  }
+
+  .message-count {
+    font-size: 18px;
   }
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -13,3 +13,6 @@ export const NOTO_SANS = "Noto Sans";
 export const PRETENDARD = "Pretendard";
 export const NANUM_MYEONGJO = "나눔명조";
 export const NANUM_HANDLETTER = "나눔손글씨 손편지체";
+
+export const POST_PAGE = "post";
+export const LIST_PAGE = "list";

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -61,6 +61,13 @@ $regular: 400;
   @include font(16px);
 }
 
+.font-16-16-14 {
+  @include font(16px);
+  @media screen and (max-width: 768px) {
+    @include size(14px);
+  }
+}
+
 .font-14-14-14 {
   @include font(14px);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,6 +88,7 @@ a {
   --orange200: #ffe2ad;
   --orange100: #fff0d6;
 
+  --gray-bolder: #e3e3e3;
   /* font-weight */
   --bold: 700;
   --regular: 400;


### PR DESCRIPTION
## 주요 변경사항

- CountMessage 컴포넌트 디자인 피그마와 다른 부분 수정
- 롤링페이퍼 페이지 내비게이션에 해당 컴포넌트 적용

## 스크린샷
<img width="836" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/6a4096c0-7114-4260-8262-c4e0e012f906">
<img width="616" alt="image" src="https://github.com/un0211/ro1ling/assets/24778465/1c622c36-15e1-41d5-b7c9-de7ea9428197">

## 팀원에게

- 서하님, 디자인 변경 + 공유를 위한 일부 코드 수정 있었습니다. 확인 부탁드려요 
- 텅 빈것도 이상하긴 한데, 오류같은 메세지가 뜨는 게 더 이상한 것 같아서 메세지 일단 제거했습니다.
