### PR TITLE
[Create Page]컬러 배경 선택 후 동일한 위치에 있는 배경 선택 안 되는 버그 해결

### DIFF
--- a/src/components/CreateRollingPaperPage/Background.js
+++ b/src/components/CreateRollingPaperPage/Background.js
@@ -10,7 +10,7 @@ export default function Background({
 }) {
   return (
     <>
-      {backgrounds.map((background, index) => (
+      {backgrounds.map((background) => (
         <>
           <input
             type="radio"
@@ -19,7 +19,7 @@ export default function Background({
             value={name === "color" ? background : BACKGROUND_IMAGE[background]}
             className={styles["select-bg-input"]}
             onChange={onBackgroundSelect}
-            key={index}
+            key={background}
           />
           <label
             htmlFor={background}

--- a/src/pages/CreateRollingPaperPage.js
+++ b/src/pages/CreateRollingPaperPage.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import styles from "./CreateRollingPaperPage.module.scss";
 import {
   BACKGROUND_COLOR,
+  BACKGROUND_IMAGE,
   BACKGROUND_IMAGE_NAME,
 } from "constants/createRollingPaperPage";
 import { createPaper } from "apis/createRollingPaperPage";
@@ -23,9 +24,11 @@ export default function CreateRollingPaPer() {
   // NOTE - 배경 컬러, 이미지 중 선택하는 함수
   const handleBgSelect = (type) => {
     setSelectedBg(type);
-
-    // NOTE - 배경 컬러인 경우 backgroundImg 초기화
-    if (type === "color") {
+    // NOTE - 컬러나 이미지 클릭 시 값 기본값으로 초기화
+    if (type === "image") {
+      setBackgroundImg(BACKGROUND_IMAGE.first);
+    } else {
+      setBackgroundColor(BACKGROUND_COLOR[0]);
       setBackgroundImg(null);
     }
   };
@@ -64,6 +67,10 @@ export default function CreateRollingPaPer() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    // NOTE - 생성하기 버튼을 누를 때 선택된 값이 color일 경우 배경 이미지 null 해주어야 함
+    // if (selectedBg === "color") {
+    //   setBackgroundImg(null);
+    // }
     let result;
     const data = {
       team: "6-1",


### PR DESCRIPTION
## 주요 변경사항

- 컬러 배경 선택한 후에 동일한 위치에 있는 이미지 배경 선택 안 되는 버그 해결했습니다 ! 
- key를 index로 써서 발생한 이슈였어요 ㅎㅎ 
-

## 스크린샷



https://github.com/un0211/ro1ling/assets/135966211/b83edf91-372c-49b8-a8a0-cfcea4b745c8





## 팀원에게

- 그리고 컬러 선택한 후에 이미지 갔다가, 다시 컬러로 돌아오면 이전에 선택했던 게 초기화 되지 않고 그대로 있게 했는데, 
- 이미지 선택하고 다시 컬러 돌아왔을 때 사용자 선택값을 초기화해서 베이지(기본값)로 적용하는 게 나을까요 ? 
-
## 변경 
- 이미지와 컬러 모두 체크 표시 적용(기본값) 
- 배경 카테고리 변경 시 이미지와 컬러 모두 기본값으로 초기화하도록 변경 
- 카테고리 변경해도 기존 선택했던 값 유지하려고 했는데 그렇게 되면 생성하기 버튼을 누를 때 현재 카테고리 값을 확인하고 , 현재 카테고리가 컬러라면 배경이미지 state 값을 null로 변경해주어야 하는데 그게 적용이 안 돼요 (아마 리액트 생명주기와 관련이 있지 않나 싶어요 ) 그래서 이게 최선일 거 같습니다 ! 
