### PR TITLE
[post message page]sender 빈 값일 때 focusout 시 에러 메세지 안 뜨는 오류 해결

### DIFF
--- a/src/pages/PostMessagePage.js
+++ b/src/pages/PostMessagePage.js
@@ -14,6 +14,7 @@ import {
 } from "constants/postMessagePage";
 import { useParams, useNavigate } from "react-router-dom";
 import { postMessage } from "apis/recipients";
+import { useEffect } from "react";
 
 export default function PostMessageForm() {
   const [senderValue, setSenderValue] = useState("");
@@ -25,7 +26,6 @@ export default function PostMessageForm() {
   const [selectedFont, setSelectedFont] = useState("Noto Sans");
   const [selectedProfile, setSelectedProfile] = useState(DEFUALT_PROFILE);
   const [editorContent, setEditorContent] = useState("");
-  const [senderContent, setSenderContent] = useState("");
 
   // NOTE - id 받아오는 작업
   const { postId } = useParams();
@@ -34,8 +34,10 @@ export default function PostMessageForm() {
   const handleNameChange = (e) => {
     const name = e.target.value.trim(); //NOTE 공백을 제거하여 입력값 확인
     setSenderValue(name);
-    setSenderContent(name); //NOTE 보낸이 내용을 상태에 업데이트
-    setSenderError(name === ""); //NOTE 공백이면 에러 상태를 true로 설정
+    // NOTE - 1글자 이상 입력 중 에러 메세지 사라지도록 처리
+    if (name.length > 0) {
+      setSenderError(false);
+    }
   };
 
   const handleEditorChange = (state) => {
@@ -47,16 +49,21 @@ export default function PostMessageForm() {
     setEditorError(isEmpty);
   };
 
-  const isButtonDisabled =
-    !editorState || !senderContent || senderError || editorError;
+  const handleSenderFocusOut = () => {
+    if (senderValue.trim() === "") {
+      setSenderError(true);
+    }
+  };
 
   const handleProfileSelect = (src) => {
     setSelectedProfile(src);
   };
 
+  const isButtonDisabled =
+    !editorContent || !senderValue || senderError || editorError;
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log(">> 보내는 데이터 : " + editorContent);
 
     const formData = {
       team: "6-1",
@@ -90,6 +97,7 @@ export default function PostMessageForm() {
           </label>
           <input
             onChange={handleNameChange}
+            onBlur={handleSenderFocusOut}
             className={`${styles["message-form-inputs"]} ${
               styles["message-form-name-input"]
             } ${senderError ? styles.error : ""}`}


### PR DESCRIPTION
## 주요 변경사항

- sender에서 포커스 아웃할 때 에러 안 뜨는 버그 해결
- 에디터 라이브러리는 onBlur를 사용할 수 없다고 나오네요 그래서 onChange로 에러 메세지 상태 변경해야 하는데 매끄럽진 않습니다 ㅜㅜ 디스코드에 올린 영상 참고해주세요 !!

## 스크린샷

![image](이미지url)

## 팀원에게

-
-
